### PR TITLE
update: improvement bug fix pdf document viewer for large file not shown

### DIFF
--- a/components/KlaimRW/ViewDocument/index.vue
+++ b/components/KlaimRW/ViewDocument/index.vue
@@ -9,11 +9,7 @@
           <jds-spinner size="72px" />
         </div>
         <div v-else-if="file !== 'loading'" class="max-h-[calc(100vh-64px-120px)] overflow-scroll">
-          <embed
-            :src="'data:application/pdf;base64,' + file"
-            type="application/pdf"
-            class="min-h-[600px] w-full"
-          >
+          <iframe :src="fileDocument" class="min-h-[600px] w-full" />
         </div>
         <div v-else class="px-4">
           Tidak ada data
@@ -27,6 +23,7 @@
 </template>
 
 <script>
+import { base64PDFToBlobUrl } from '~/utils'
 export default {
   name: 'ViewDocument',
   props: {
@@ -50,6 +47,11 @@ export default {
     file: {
       type: String,
       default: ''
+    }
+  },
+  computed: {
+    fileDocument () {
+      return this.file ? base64PDFToBlobUrl(this.file) : ''
     }
   },
   methods: {

--- a/utils/index.js
+++ b/utils/index.js
@@ -15,3 +15,15 @@ export function formatDate (date) {
     return '-'
   }
 }
+
+export function base64PDFToBlobUrl (base64) {
+  const binStr = atob(base64)
+  const len = binStr.length
+  const arr = new Uint8Array(len)
+  for (let i = 0; i < len; i++) {
+    arr[i] = binStr.charCodeAt(i)
+  }
+  const blob = new Blob([arr], { type: 'application/pdf' })
+  const url = URL.createObjectURL(blob)
+  return url
+}


### PR DESCRIPTION
## Overview
Bug: For pdf larger than 2 MB cannot load with base64 format

## Changes
- Create function base64PDFToBlobUrl
- Change source view from base64 to BlobUrl

## Evidence
title: improvement bug fix pdf document viewer for large file not shown
project: Jabar Super Apps
participants: @yoslie 
