### PR TITLE
refactor : check default complaint type for sort by updated date on page list determining authority

### DIFF
--- a/components/Aduan/index.vue
+++ b/components/Aduan/index.vue
@@ -592,8 +592,8 @@ export default {
       this.isShowPopupDateRange = true
     },
     checkComplaintTypeSortByUpdatedDateHandle () {
-      const listCmplaintTypeSortByUpdatedDate = [this.typeAduan.penentuanKewenangan.props]
-      return listCmplaintTypeSortByUpdatedDate.includes(this.typeAduanPage)
+      const listComplaintTypeSortByUpdatedDate = [this.typeAduan.penentuanKewenangan.props]
+      return listComplaintTypeSortByUpdatedDate.includes(this.typeAduanPage)
     }
   }
 }

--- a/components/Aduan/index.vue
+++ b/components/Aduan/index.vue
@@ -299,6 +299,11 @@ export default {
         this.setQuery({ complaint_source: 'sp4n' })
       }
 
+      // default sort by updated date
+      if (this.checkComplaintTypeSortByUpdatedDateHandle()) {
+        this.setQuery({ sort_by: 'updated_at' })
+      }
+
       const responseListComplaint = await this.$axios.get('/warga/complaints', {
         params: { ...this.query, is_admin: 1 }
       })
@@ -585,6 +590,10 @@ export default {
     },
     changeDateRangeHandle () {
       this.isShowPopupDateRange = true
+    },
+    checkComplaintTypeSortByUpdatedDateHandle () {
+      const listCmplaintTypeSortByUpdatedDate = [this.typeAduan.penentuanKewenangan.props]
+      return listCmplaintTypeSortByUpdatedDate.includes(this.typeAduanPage)
     }
   }
 }


### PR DESCRIPTION
## Changes
- add function for check default complaint type sort by updated date 

## Evidence
title: refactor check default complaint type for sort by updated date on page list determining authority
project: Jabar Super Apps
participants: @marsellavaleria19 @rayfajars @yoslie 


