### PR TITLE
feat: add reload current page back from detail klaim rw pages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.fixAll.eslint": true
+    "source.fixAll": "explicit",
+    "source.fixAll.eslint": "explicit"
   },
 
   // Use Prettier as default formatter for .vue file

--- a/components/KlaimRW/KlaimRwDetail/index.vue
+++ b/components/KlaimRW/KlaimRwDetail/index.vue
@@ -16,7 +16,7 @@
         <BaseButton
           v-show="detail.rwStatus == userStatus.waiting"
           class="mr-[12px] w-fit border border-red-400 text-red-400 hover:bg-red-50"
-          @click="confirmationDialog.showReject=true"
+          @click="confirmationDialog.showReject = true"
         >
           Tolak Akun RW Ini
         </BaseButton>
@@ -209,7 +209,11 @@
       @submit="actionRejectUser"
       @close="confirmationDialog.showReject = false"
     />
-    <BasePopup :show-popup="showPopupConfirmationInformation" @submit="actionVerifyUser" @close="onClosePopupInfo" />
+    <BasePopup
+      :show-popup="showPopupConfirmationInformation"
+      @submit="actionVerifyUser"
+      @close="onClosePopupInfo"
+    />
     <InformationPopup
       :show-popup="informationDialog.show"
       :account-name="detail?.name || '-'"
@@ -325,7 +329,10 @@ export default {
   },
   methods: {
     goBackHandle () {
-      this.$router.push('/')
+      this.$router.push({
+        path: '/',
+        query: this.$route.query
+      })
     },
     rejectConfirmationHandle () {
       this.confirmationDialog.showReject = true

--- a/components/KlaimRW/index.vue
+++ b/components/KlaimRW/index.vue
@@ -59,7 +59,7 @@
         <template #item.action="{ item }">
           <KlaimRWTableAction
             :status="item.rwStatus"
-            @detail="$router.push(`/detail/${item.id}`)"
+            @detail="goToDetail(item.id)"
             @verify="showVerifyPopupHandle(item)"
             @reject="rejectUser(item)"
           />
@@ -88,7 +88,11 @@
       @close="showRejectRw = false"
       @submit="actionRejectUser"
     />
-    <BasePopup :show-popup="showPopupConfirmationInformation" @submit="actionVerifyUser" @close="onClosePopupInfo" />
+    <BasePopup
+      :show-popup="showPopupConfirmationInformation"
+      @submit="actionVerifyUser"
+      @close="onClosePopupInfo"
+    />
     <PopupInformation
       :show-popup="informationDialog.show"
       :title="informationDialog.title"
@@ -152,6 +156,7 @@ export default {
       const response = await this.$axios.get('/user/rw', {
         params: this.query
       })
+
       const { data } = response.data
       this.data = data?.data || []
       if (this.data.length) {
@@ -176,12 +181,30 @@ export default {
       })
     }
   },
+
   watch: {
     query: {
       deep: true,
       handler () {
+        if (Object.keys(this.$route.query).length > 0) {
+          this.$router.replace({
+            path: this.$route.path,
+            query: {}
+          })
+        }
+
         this.$fetch()
       }
+    },
+    '$route.query': {
+      handler (newQuery) {
+        if (Object.keys(newQuery).length > 0) {
+          this.query = { ...newQuery }
+          this.search = this.query.nameFilter || ''
+        }
+      },
+      deep: true,
+      immediate: true
     }
   },
   mounted () {
@@ -270,6 +293,12 @@ export default {
       } catch {
         this.informationDialog.file = ''
       }
+    },
+    goToDetail (id) {
+      this.$router.push({
+        path: `/detail/${id}`,
+        query: this.query
+      })
     }
   }
 }
@@ -288,5 +317,4 @@ export default {
 .jds-data-table:deep tr td {
   @apply min-w-[170px] border-r border-gray-200;
 }
-
 </style>

--- a/components/KlaimRW/index.vue
+++ b/components/KlaimRW/index.vue
@@ -110,7 +110,7 @@ import PopupRejectRw from './Popup/RejectConfirmation.vue'
 import PopupInformation from './Popup/Information.vue'
 import popup from '~/mixins/klaim-rw'
 import { headerTableKlaimRW, userStatus } from '~/constant/klaim-rw'
-import { generateItemsPerPageOptions, formatDate } from '~/utils'
+import { generateItemsPerPageOptions, formatDate, resetQueryParamsUrl } from '~/utils'
 
 export default {
   name: 'ComponentKlaimRW',
@@ -186,25 +186,21 @@ export default {
     query: {
       deep: true,
       handler () {
-        if (Object.keys(this.$route.query).length > 0) {
-          this.$router.replace({
-            path: this.$route.path,
-            query: {}
-          })
-        }
+        resetQueryParamsUrl(this)
 
         this.$fetch()
       }
     },
     '$route.query': {
+      deep: true,
+      immediate: true,
       handler (newQuery) {
         if (Object.keys(newQuery).length > 0) {
           this.query = { ...newQuery }
           this.search = this.query.nameFilter || ''
         }
-      },
-      deep: true,
-      immediate: true
+      }
+
     }
   },
   mounted () {

--- a/utils/index.js
+++ b/utils/index.js
@@ -78,3 +78,13 @@ export function convertToUnit (value) {
   }
   return units[unitIndex]
 }
+
+export function resetQueryParamsUrl (context) {
+  if (Object.keys(context.$route.query).length > 0) {
+    // replace query params url with empty object
+    context.$router.replace({
+      path: context.$route.path,
+      query: {}
+    })
+  }
+}


### PR DESCRIPTION
## Related
https://app.clickup.com/t/9003239225/CES-1317

## FEAT
added a function to return the query table when returning from the details page


## Evidence
title: added a function to return the query table when returning from the details page
project: Jabar Super Apps
participants: @rayfajars @marsellavaleria19 @marsellavaleria19 @doohanas 


