### PR TITLE
remove menutitle props in sidebaritem component

### DIFF
--- a/components/Sidebar/Item.vue
+++ b/components/Sidebar/Item.vue
@@ -45,10 +45,6 @@ export default {
       type: Boolean,
       default: true,
     },
-    menuTitle: {
-      type: String,
-      default: null,
-    },
   },
   computed: {
     pageActive() {

--- a/components/Sidebar/index.vue
+++ b/components/Sidebar/index.vue
@@ -24,7 +24,6 @@
             :is-show-arrow="menuSidebar.arrow"
             :link="menuSidebar.path"
             :icon="menuSidebar.icon"
-            :menu-title="menuSidebar?.titleMenu"
           />
         </div>
       </div>


### PR DESCRIPTION
## Related
[CMS TMS - Issue active hover on title menu](https://app.clickup.com/t/86cuhyra3)

## Changes
remove menutitle props in sidebaritem component

## Preview


## Evidence
title: remove menutitle props in sidebaritem component
project: Jabar Super Apps
participants: @rizfirman @Ibwedagama @agunghide @rayfajars @marsellavaleria19 


