### PR TITLE
remove 'after six day' validation in reschedule date picker

### DIFF
--- a/components/Sribaduga/DialogReschedule/index.vue
+++ b/components/Sribaduga/DialogReschedule/index.vue
@@ -83,6 +83,10 @@ export default {
       type: String,
       default: '',
     },
+    holidayList: {
+      type: Array,
+      default: () => [],
+    },
   },
   data() {
     return {
@@ -158,10 +162,12 @@ export default {
       }
     },
     disableDate(date) {
-      return (
-        date < new Date() ||
-        date > new Date(new Date().setDate(new Date().getDate() + 6))
+      const dateToCompare = formatDate(date, 'yyyy-MM-dd')
+      const isHoliday = this.holidayList.some(
+        (holiday) => formatDate(holiday.date, 'yyyy-MM-dd') === dateToCompare
       )
+
+      return date < new Date() || isHoliday
     },
     closeDialogReschedule() {
       this.$store.commit('modals/CLOSE', 'dialog-reschedule')

--- a/components/Sribaduga/KalenderReservasi/index.vue
+++ b/components/Sribaduga/KalenderReservasi/index.vue
@@ -231,6 +231,7 @@
               :reschedule-value="rescheduleValue"
               :options="sessionDataListForReschedule"
               :invoice-id="invoiceId"
+              :holiday-list="holidayList"
             />
             <DialogSuccess />
             <DialogBatalkanReservasi :invoice-id="invoiceId" />


### PR DESCRIPTION
## Related
[[CMS] Sribaduga - List issue Kalender Reservasi](https://app.clickup.com/t/9003239225/CES-10574)

## Changes
- remove 'after six day' validation in reschedule date picker

## Preview


## Evidence
title: remove 'after six day' validation in reschedule date picker
project: Jabar Super Apps
participants: @rizfirman @azhargraha @Ibwedagama @marsellavaleria19 @agunghide @rayfajars 


