### PR TITLE
fix : id span not show when status coordinated and source span on page detail determining authority

### DIFF
--- a/components/Aduan/Detail/Table/Complaint/index.vue
+++ b/components/Aduan/Detail/Table/Complaint/index.vue
@@ -568,7 +568,7 @@ export default {
         case this.typeAduan.instruksiKewenanganNonPemprov.props:
           return true
         case this.typeAduan.penentuanKewenangan.props:
-          if (statusId === this.complaintStatus.verified.id) {
+          if (statusId === this.complaintStatus.coordinated.id) {
             return true
           }
           break


### PR DESCRIPTION
## Related
[[CMS Aduan] Role Penentu Kewenangan - Tambah ID span untuk aduan dari SPAN Lapor](https://app.clickup.com/t/9003239225/CES-11466)

## Changes
fixing id span not show when status coordinated and source span

## Evidence
title: fixing id span not show when status coordinated and source span on page detail determining authority
project: Jabar Super Apps
participants: @marsellavaleria19 @doohanas @rayfajars @rizfirman @Ibwedagama 


