### PR TITLE
fix : reset page when filter category & complaint status for non government

### DIFF
--- a/components/Aduan/index.vue
+++ b/components/Aduan/index.vue
@@ -578,6 +578,7 @@ export default {
         complaint_category_id: null,
         'complaint_category_id[0]': null,
       })
+      this.query.page = 1
       if (value) {
         this.query['complaint_category_id[0]'] = value
       }
@@ -585,13 +586,11 @@ export default {
     },
     filterNonGovComplaintStatusHandle(value) {
       this.query.complaint_status_id = null
+      this.query.page = 1
       if (value) {
         this.query.complaint_status_id = value
       }
       this.$fetch()
-      if (value === '') {
-        this.query.complaint_status_id = ''
-      }
     },
     goToPageDetailHandle(item) {
       this.$router.push({


### PR DESCRIPTION
## Related
[[CMS] Aduan Warga - Instruksi Kewenangan non-pemprov - Rubah Filter status tidak kembali reset data ke awal](https://app.clickup.com/t/9003239225/CES-13053)

## Changes
- reset page when filter category & complaint status for non government

## Evidence
title: fix reset page when filter category & complaint status for non government
project: Jabar Super Apps
participants: @marsellavaleria19  @doohanas @yoslie 


