### PR TITLE
Fix : id span lapor not show on page detail complaint instruction non government

### DIFF
--- a/components/Aduan/Detail/Table/Complaint/index.vue
+++ b/components/Aduan/Detail/Table/Complaint/index.vue
@@ -575,6 +575,7 @@ export default {
       switch (this.typeAduanPage) {
         case this.typeAduan.aduanDialihkanSpanLapor.props:
         case this.typeAduan.instruksiKewenanganNonPemprov.props:
+        case this.typeAduan.instruksiNonPemprov.props:
           return true
         case this.typeAduan.penentuanKewenangan.props:
           {

--- a/components/Aduan/Detail/Table/Complaint/index.vue
+++ b/components/Aduan/Detail/Table/Complaint/index.vue
@@ -271,7 +271,7 @@
           <td>{{ detailComplaint?.description || '-' }}</td>
         </tr>
         <tr>
-          <td><strong>Lokasi Kejadian</strong></td>
+          <td colspan="2"><strong>Lokasi Kejadian</strong></td>
         </tr>
         <tr>
           <td>Kabupaten / Kota</td>


### PR DESCRIPTION
## Related
[[CMS Aduan] Role Perangkat Daerah - Missing ID SP4N Lapor](https://app.clickup.com/t/9003239225/CES-13442)

## Changes
- fixing id span lapor not show on detail compaint
- add colspan attribute to td element Lokasi Kejadian

## Evidence
title: Fix id span lapor not show on page detail complaint instruction non government
project: Jabar Super Apps
participants: @marsellavaleria19 @rayfajars @Ibwedagama 


