### PR TITLE
Feat : add data cy on button submit, confirmation & information success form process complaint

### DIFF
--- a/components/Aduan/Dialog/ProcessComplaint/index.vue
+++ b/components/Aduan/Dialog/ProcessComplaint/index.vue
@@ -535,6 +535,7 @@ export default {
           button: {
             label: 'Ya, lanjutkan',
             variant: 'primary',
+            dataCy: `dialog__confirmation-process-complaint__button--confirmation`,
           },
           nameModal: 'dialogConfirmationComplaintProcess',
         }

--- a/components/Dialog/ConfirmationBasic/index.vue
+++ b/components/Dialog/ConfirmationBasic/index.vue
@@ -14,6 +14,7 @@
         <template #button-right>
           <jds-button
             :label="dialogModal?.button.label"
+            :data-cy="dialogModal.button.dataCy"
             type="button"
             :variant="dialogModal?.button.variant"
             @click="$emit('confirmation-button')"

--- a/mixins/popup-aduan-masuk.js
+++ b/mixins/popup-aduan-masuk.js
@@ -178,7 +178,7 @@ export default {
         fieldSelect: `${dataCyFormat}__select`,
         fieldSelectOptions: `${dataCyFormat}__select-dropdown`,
         footer: {
-          buttonSubmit: `${dataCyFormat}__button-submit`,
+          buttonSubmit: `${dataCyFormat}__button--process-complaint`,
         },
       }
       this.$store.commit('process-complaint/setComplaintSource', {

--- a/mixins/popup-aduan-masuk.js
+++ b/mixins/popup-aduan-masuk.js
@@ -411,10 +411,18 @@ export default {
           dialogTitle,
           dataComplaint.subDescription
         ),
-        success: this.setSucessFailedInformationHandle(
-          `${dialogTitle} berhasil dilakukan`,
-          true
-        ),
+        success: {
+          ...this.setSucessFailedInformationHandle(
+            `${dialogTitle} berhasil dilakukan`,
+            true
+          ),
+          dataCy: {
+            footer: {
+              buttonSubmit:
+                'dialog__information-success-from-process-complaint__button--close',
+            },
+          },
+        },
         failed: this.setSucessFailedInformationHandle(
           `${dialogTitle} gagal dilakukan`,
           false


### PR DESCRIPTION
## Changes
[feat : add data-cy button confirmation & information success form process complaint](https://github.com/jabardigitalservice/super-app-cms/commit/5858514e1864b9a45a40b953f18fd29e43fee589)
[fix : change data-cy name button submit form process complaint](https://github.com/jabardigitalservice/super-app-cms/commit/d9d64de16d86a9bd23d9e20180e4654cfeac3f2e)

## Evidence
title: Feat add data cy on button submit, confirmation & information success form process complaint
project: Jabar Super Apps
participants: @marsellavaleria19 @doohanas @yoslie @rizfirman @Ibwedagama 
screenshot: https://s.digitalservice.id/CQxvxE


