### PR TITLE
Feat : add form edit id span

### DIFF
--- a/components/Aduan/Dialog/AddIdSpan/index.vue
+++ b/components/Aduan/Dialog/AddIdSpan/index.vue
@@ -117,7 +117,6 @@ export default {
       const currentDate = new Date()
       const oneMonthAgo = new Date(currentDate)
       oneMonthAgo.setMonth(currentDate.getMonth() - 1) // Kurangi 1 bulan
-      oneMonthAgo.setDate(currentDate.getDate()) // tanggal se
       return date < oneMonthAgo || date > currentDate
     },
     clearDate() {

--- a/components/Aduan/Dialog/AddIdSpan/index.vue
+++ b/components/Aduan/Dialog/AddIdSpan/index.vue
@@ -82,6 +82,8 @@
 
 <script>
 import { ValidationProvider, ValidationObserver } from 'vee-validate'
+import { formatDate } from '~/utils'
+
 export default {
   name: 'DialogInputTextArea',
   components: { ValidationProvider, ValidationObserver },
@@ -115,7 +117,7 @@ export default {
       const currentDate = new Date()
       const oneMonthAgo = new Date(currentDate)
       oneMonthAgo.setMonth(currentDate.getMonth() - 1) // Kurangi 1 bulan
-      oneMonthAgo.setDate(currentDate.getDate() - 1) // Kurangi 1 hari
+      oneMonthAgo.setDate(currentDate.getDate()) // tanggal se
       return date < oneMonthAgo || date > currentDate
     },
     clearDate() {
@@ -137,7 +139,7 @@ export default {
           },
         }
 
-        // dialog confirmation edit i
+        // dialog confirmation edit id span
         if (this.nameModal === 'formEditIdSpan') {
           dataDialog.title = 'Ubah ID SP4N Lapor'
           dataDialog.descriptionText =
@@ -149,10 +151,18 @@ export default {
       }
     },
     submitIdSpan() {
+      const spanCreatedDate = formatDate(
+        this.payload.sp4n_created_at,
+        'yyyy-MM-dd'
+      )
+      const [year, month, day] = spanCreatedDate.split('-')
+      const date = new Date(Date.UTC(year, month - 1, day, 0, 0, 0))
+      this.payload.sp4n_created_at = date
       this.$emit('submit', {
         subDescription: this.dataDialog.subDescription,
         payload: this.payload,
       })
+
       this.clearForm()
     },
     backToForm() {

--- a/components/Aduan/Dialog/AddIdSpan/index.vue
+++ b/components/Aduan/Dialog/AddIdSpan/index.vue
@@ -97,10 +97,6 @@ export default {
   },
   data() {
     return {
-      // payload: {
-      //   sp4n_id: '',
-      //   sp4n_created_at: '',
-      // },
       dialogConfirmation: {},
     }
   },
@@ -141,7 +137,7 @@ export default {
           },
         }
 
-        // dialog confirmation edit id span
+        // dialog confirmation edit i
         if (this.nameModal === 'formEditIdSpan') {
           dataDialog.title = 'Ubah ID SP4N Lapor'
           dataDialog.descriptionText =
@@ -164,10 +160,10 @@ export default {
       this.$store.commit('modals/OPEN', this.nameModal)
     },
     clearForm() {
-      this.payload = {
+      this.$store.commit('id-span/setPayload', {
         sp4n_created_at: '',
         sp4n_id: '',
-      }
+      })
     },
   },
 }

--- a/components/Aduan/Dialog/AddIdSpan/index.vue
+++ b/components/Aduan/Dialog/AddIdSpan/index.vue
@@ -2,7 +2,7 @@
   <div>
     <BaseDialogFrame :name="nameModal">
       <BaseDialogPanel>
-        <BaseDialogHeader title="Tambahkan ID SP4N Lapor" />
+        <BaseDialogHeader :title="dataDialog.title" />
         <ValidationObserver ref="form" v-slot="{ invalid }">
           <form>
             <div class="px-6 pb-3">
@@ -57,10 +57,10 @@
                 </ValidationProvider>
               </div>
             </div>
-            <BaseDialogFooterNew name="formAddIdSpan" @cancel="clearForm()">
+            <BaseDialogFooterNew :name="nameModal" @cancel="clearForm()">
               <template #button-right>
                 <jds-button
-                  label="Tambahkan"
+                  :label="dataDialog.labelButtonSubmit"
                   type="button"
                   variant="primary"
                   :disabled="invalid"
@@ -86,24 +86,33 @@ export default {
   name: 'DialogInputTextArea',
   components: { ValidationProvider, ValidationObserver },
   props: {
-    showPopup: {
-      type: Boolean,
-      default: false,
-    },
     dataDialog: {
       type: Object,
       default: () => ({}),
     },
+    nameModal: {
+      type: String,
+      default: '',
+    },
   },
   data() {
     return {
-      payload: {
-        sp4n_id: '',
-        sp4n_created_at: '',
-      },
-      nameModal: 'formAddIdSpan',
+      // payload: {
+      //   sp4n_id: '',
+      //   sp4n_created_at: '',
+      // },
       dialogConfirmation: {},
     }
+  },
+  computed: {
+    payload: {
+      get() {
+        return { ...this.$store.state['id-span'].payload }
+      },
+      set(value) {
+        this.$store.commit('id-span/setPayload', value)
+      },
+    },
   },
   methods: {
     disabledDate: function (date) {
@@ -120,6 +129,7 @@ export default {
       const isValid = await this.$refs.form.validate()
       if (isValid) {
         this.$store.commit('modals/CLOSEALL')
+        // dialog confirmation add id span
         const dataDialog = {
           title: 'Tambahkan ID SP4N Lapor',
           nameModal: `${this.nameModal}Confirmation`,
@@ -129,6 +139,13 @@ export default {
             label: 'Ya, lanjutkan',
             variant: 'primary',
           },
+        }
+
+        // dialog confirmation edit id span
+        if (this.nameModal === 'formEditIdSpan') {
+          dataDialog.title = 'Ubah ID SP4N Lapor'
+          dataDialog.descriptionText =
+            'Apakah anda yakin ingin mengubah ID SP4N Lapor tersebut?'
         }
         this.dialogConfirmation = dataDialog
         this.$store.commit('modals/OPEN', dataDialog.nameModal)

--- a/components/Aduan/index.vue
+++ b/components/Aduan/index.vue
@@ -160,7 +160,10 @@
                 @evidence-followup-hotline="
                   showPopupEvidenceFollowupHotline(item)
                 "
-                @add-id-span="showPopupInputIdSpanHandle(item)"
+                @add-id-span="showPopupInputIdSpanHandle(item, 'formAddIdSpan')"
+                @edit-id-span="
+                  showPopupInputIdSpanHandle(item, 'formEditIdSpan')
+                "
                 @process-complaint="showPopupProcessComplaintHandle(item)"
                 @change-authority="showPopupChangeAuthority(item)"
                 @followup-complaint="showPopupFollowupComplaint(item)"
@@ -209,7 +212,7 @@
     />
     <DialogAddIdSpan
       :data-dialog="dataDialog"
-      name-modal="formAddIdSpan"
+      :name-modal="dataDialog.nameModal"
       @submit="submitInputIdSpanHandle"
     />
     <DialogProcessComplaint

--- a/components/Aduan/index.vue
+++ b/components/Aduan/index.vue
@@ -160,7 +160,7 @@
                 @evidence-followup-hotline="
                   showPopupEvidenceFollowupHotline(item)
                 "
-                @add-span="showPopupInputIdSpanHandle(item)"
+                @add-id-span="showPopupInputIdSpanHandle(item)"
                 @process-complaint="showPopupProcessComplaintHandle(item)"
                 @change-authority="showPopupChangeAuthority(item)"
                 @followup-complaint="showPopupFollowupComplaint(item)"
@@ -341,9 +341,15 @@ export default {
         },
         {
           menu: 'Tambahkan ID SP4N Lapor',
-          value: 'add-span',
+          value: 'add-id-span',
           complaintType: [typeAduan.aduanDialihkanSpanLapor.props],
           complaintStatus: ['no-id-span'],
+        },
+        {
+          menu: 'Ubah ID SP4N Lapor',
+          value: 'edit-id-span',
+          complaintType: [typeAduan.aduanDialihkanSpanLapor.props],
+          complaintStatus: [complaintStatus.diverted_to_span.id],
         },
         {
           menu: 'Proses Aduan',

--- a/mixins/popup-aduan-masuk.js
+++ b/mixins/popup-aduan-masuk.js
@@ -196,9 +196,12 @@ export default {
           title: 'Ubah ID SP4N Lapor',
           labelButtonSubmit: 'Ubah Data',
         })
+
+        const [date, month, year] = dataComplaint.sp4n_created_at.split('/')
+
         this.$store.commit('id-span/setPayload', {
           sp4n_id: dataComplaint.sp4n_id,
-          sp4n_created_at: new Date(dataComplaint?.deadline_date),
+          sp4n_created_at: new Date(year, month - 1, date),
         })
       }
 

--- a/mixins/popup-aduan-masuk.js
+++ b/mixins/popup-aduan-masuk.js
@@ -177,15 +177,32 @@ export default {
       })
       this.isShowPopupConfirmationFailedVerification = true
     },
-    showPopupInputIdSpanHandle(dataComplaint) {
+    showPopupInputIdSpanHandle(dataComplaint, dialogName) {
       this.idApi = dataComplaint.id
       this.typeDialog = 'addIdSpan'
       this.dataComplaint = dataComplaint
       this.setDataDialog({
         description: 'No. Aduan',
         subDescription: dataComplaint.complaint_id,
+        nameModal: dialogName,
+        title: 'Tambahkan ID SP4N Lapor',
+        labelButtonSubmit: 'Tambahkan',
       })
-      this.$store.commit('modals/OPEN', 'formAddIdSpan')
+
+      // show form edit id span
+      if (dialogName === 'formEditIdSpan') {
+        this.typeDialog = 'editIdSpan'
+        this.setDataDialog({
+          title: 'Ubah ID SP4N Lapor',
+          labelButtonSubmit: 'Ubah Data',
+        })
+        this.$store.commit('id-span/setPayload', {
+          sp4n_id: dataComplaint.sp4n_id,
+          sp4n_created_at: new Date(dataComplaint?.deadline_date),
+        })
+      }
+
+      this.$store.commit('modals/OPEN', dialogName)
     },
     showPopupProcessComplaintHandle(dataComplaint) {
       this.idApi = dataComplaint.id
@@ -367,6 +384,8 @@ export default {
     submitInputIdSpanHandle(item) {
       this.$store.commit('modals/CLOSEALL')
       let dataDialogInformation = {}
+
+      // information add id span
       dataDialogInformation = {
         ...this.setDataDialogInformation('ID SP4N Lapor', item.subDescription),
         success: this.setSucessFailedInformationHandle(
@@ -377,6 +396,18 @@ export default {
           'ID SP4N Lapor gagal ditambah',
           false
         ),
+      }
+
+      // information edit id span
+      if (this.typeDialog === 'editIdSpan') {
+        dataDialogInformation.success = this.setSucessFailedInformationHandle(
+          'ID SP4N Lapor berhasil diubah',
+          true
+        )
+        dataDialogInformation.failed = this.setSucessFailedInformationHandle(
+          'ID SP4N Lapor gagal diubah',
+          false
+        )
       }
       this.integrationPopupHandle(
         dataDialogInformation,

--- a/store/id-span.js
+++ b/store/id-span.js
@@ -1,0 +1,12 @@
+export const state = () => ({
+  payload: {
+    sp4n_created_at: '',
+    sp4n_id: '',
+  },
+})
+
+export const mutations = {
+  setPayload(state, payload) {
+    state.payload = payload
+  },
+}


### PR DESCRIPTION
## Related
[[Aduan Warga] CMS - Menambahkan Aksi Ubah ID Span pada menu Dialihkan ke Span](https://app.clickup.com/t/9003239225/CES-15748)

## Changes
[add show form edit id span on button action](https://github.com/jabardigitalservice/super-app-cms/commit/6eeead441bb10bfd4c66b78cb87c9dbec334ebd1)
[adjust for form edit id span](https://github.com/jabardigitalservice/super-app-cms/commit/740fdcbe8e5e44e70bef56dd761c7fb6f1dc722c)
[adjust dialog confirmation for form edit id span](https://github.com/jabardigitalservice/super-app-cms/commit/8e3620cf297d1011caeb29b5e4a4c6d2a62cca34)
[add payload on state management id span](https://github.com/jabardigitalservice/super-app-cms/commit/58c8198df04b9500e8b3a969d2679610baea4dba)

## Preview
![image](https://github.com/user-attachments/assets/4ecb2924-f580-4a16-a3d8-d3cd4386ee84)

## Evidence
title:  Feat add form edit id span
project: Sapawarga
participants: @marsellavaleria19 @doohanas @rayfajars @agunghide 
screenshot: https://s.digitalservice.id/BbaqIi
