### PR TITLE
Fix : add limit character of field instruction note form create instruction and field report content on form add complaint

### DIFF
--- a/components/Aduan/Dialog/AddComplaint/Form/InformationComplaint/index.vue
+++ b/components/Aduan/Dialog/AddComplaint/Form/InformationComplaint/index.vue
@@ -111,11 +111,6 @@ export default {
       default: false,
     },
   },
-  data() {
-    return {
-      description: '',
-    }
-  },
   computed: {
     dataInformationComplaint: {
       get() {
@@ -125,6 +120,18 @@ export default {
       },
       set(value) {
         this.$store.commit('add-complaint/setDataInformationComplaint', value)
+      },
+    },
+    description: {
+      get() {
+        return this.$store.getters['add-complaint/getDataInformationComplaint']
+          .description
+      },
+      set(value) {
+        this.$store.commit('add-complaint/setDataInformationComplaint', {
+          ...this.dataInformationComplaint,
+          description: value,
+        })
       },
     },
   },
@@ -143,7 +150,6 @@ export default {
             this.dataInformationComplaint.span_created_at || '',
             'yyyy-MM-dd'
           ),
-          description: this.description,
         })
         this.isSubmit = false
       }

--- a/components/Aduan/Dialog/AddComplaint/Form/InformationComplaint/index.vue
+++ b/components/Aduan/Dialog/AddComplaint/Form/InformationComplaint/index.vue
@@ -85,13 +85,13 @@
             placeholder="Masukkan Isi Laporan"
             label="Isi Laporan"
             name="Isi Laporan"
-            maxlength="255"
+            maxlength="1000"
             :error-message="errors[0]"
           />
         </ValidationProvider>
         <p class="text-sm text-gray-600">
           Tersisa
-          {{ 255 - description.length }} karakter
+          {{ 1000 - description.length }} karakter
         </p>
       </form>
     </ValidationObserver>

--- a/components/Aduan/Dialog/AddComplaint/Form/LocationComplaint/index.vue
+++ b/components/Aduan/Dialog/AddComplaint/Form/LocationComplaint/index.vue
@@ -124,7 +124,6 @@ export default {
       listDataCity: [],
       listDataDistrict: [],
       listDataVillage: [],
-      addressDetail: '',
       isSubmit: false,
     }
   },
@@ -154,6 +153,18 @@ export default {
       },
       set(value) {
         this.$store.commit('add-complaint/setDataLocationComplaint', value)
+      },
+    },
+    addressDetail: {
+      get() {
+        return this.$store.getters['add-complaint/getDataLocationComplaint']
+          .address_detail
+      },
+      set(value) {
+        this.$store.commit('add-complaint/setDataLocationComplaint', {
+          ...this.dataLocationComplaint,
+          address_detail: value,
+        })
       },
     },
   },
@@ -198,7 +209,6 @@ export default {
         this.dataLocationComplaint.village_name = village.name
         this.$store.commit('add-complaint/setDataLocationComplaint', {
           ...this.dataLocationComplaint,
-          address_detail: this.addressDetail,
         })
         this.isSubmit = false
       }

--- a/components/Aduan/Dialog/CreateIkp/index.vue
+++ b/components/Aduan/Dialog/CreateIkp/index.vue
@@ -182,13 +182,13 @@
                     v-model="instructionNote"
                     label="Keterangan Instruksi Aduan"
                     placeholder="Masukkan deskripsi"
-                    maxlength="255"
+                    maxlength="1000"
                     class="pt-3"
                     :error-message="errors[0]"
                   />
                 </ValidationProvider>
                 <p class="pt-1 text-xs text-gray-600">
-                  Tersisa {{ 255 - instructionNote.length }} karakter
+                  Tersisa {{ 1000 - instructionNote.length }} karakter
                 </p>
               </form>
             </ValidationObserver>

--- a/store/add-complaint.js
+++ b/store/add-complaint.js
@@ -40,6 +40,9 @@ export const getters = {
   getDataInformationComplaint: (state) => {
     return state.dataInformationComplaint
   },
+  getDataLocationComplaint: (state) => {
+    return state.dataLocationComplaint
+  },
   getIsValidFormLocationComplaint: (state) => {
     return state.isValidFormLocationComplaint
   },


### PR DESCRIPTION
## Related
[[Aduan Warga] Menambah limit karakter di Keterangan Instruksi Aduan](https://app.clickup.com/t/9003239225/CES-29746)
[[Aduan Warga] Menambah limit karakter pada field Isi laporan - Pop up Aduan dari Span](https://app.clickup.com/t/9003239225/CES-29784)

## Changes
[fix(create instruction) : add limit character instruction note.](https://github.com/jabardigitalservice/super-app-cms/commit/e98ca357c43e37fdc3bed6f15978e0182cca3be9)
[fix(form add complaint) : add limit report content](https://github.com/jabardigitalservice/super-app-cms/commit/46e0af66ab625a303b2747f07de79ad143af3425)

## Preview
![image](https://github.com/user-attachments/assets/2ddcb11d-ae16-4a3e-bbd7-5847acf076b1)
![image](https://github.com/user-attachments/assets/9628dd72-d525-4d17-9b09-8f93adb1b6f0)

## Evidence

title:  Fix add limit character of field instruction note form create instruction and field report content on form add complaint
project: Sapawarga
participants: @marsellavaleria19 @DzikriAzzakah @agunghide @yoslie @doohanas 
screenshot: https://s.digitalservice.id/bnw0Vs
