### PR TITLE
fix(diverted to span) : issue field coverage of affairs,opd name & other information not show on page detail

### DIFF
--- a/constant/aduan-masuk.js
+++ b/constant/aduan-masuk.js
@@ -495,6 +495,7 @@ export const detailField = {
           complaintStatus.finished.id,
           complaintStatus.not_yet_instructed.id,
           complaintStatus.not_yet_coordinated.id,
+          'no-id-span',
         ],
       },
       {
@@ -558,6 +559,7 @@ export const detailField = {
           complaintStatus.finished.id,
           complaintStatus.not_yet_instructed.id,
           complaintStatus.not_yet_coordinated.id,
+          'no-id-span',
         ],
       },
       {
@@ -589,6 +591,7 @@ export const detailField = {
           complaintStatus.not_yet_instructed.id,
           complaintStatus.not_yet_coordinated.id,
           complaintStatus.coordinated.id,
+          'no-id-span',
         ],
       },
     ],
@@ -608,6 +611,7 @@ export const detailField = {
       complaintStatus.finished.id,
       complaintStatus.not_yet_instructed.id,
       complaintStatus.not_yet_coordinated.id,
+      'no-id-span',
     ],
   },
   otherInformation: {
@@ -632,6 +636,7 @@ export const detailField = {
           complaintStatus.followup.id,
           complaintStatus.postponed.id,
           complaintStatus.finished.id,
+          'no-id-span',
         ],
       },
       {
@@ -653,6 +658,7 @@ export const detailField = {
           complaintStatus.followup.id,
           complaintStatus.postponed.id,
           complaintStatus.finished.id,
+          'no-id-span',
         ],
       },
       {
@@ -675,6 +681,7 @@ export const detailField = {
           complaintStatus.followup.id,
           complaintStatus.postponed.id,
           complaintStatus.finished.id,
+          'no-id-span',
         ],
       },
     ],
@@ -695,6 +702,7 @@ export const detailField = {
       complaintStatus.followup.id,
       complaintStatus.postponed.id,
       complaintStatus.finished.id,
+      'no-id-span',
     ],
   },
   trackingSpan: {


### PR DESCRIPTION
## Related
[[Aduan] - Issue Field cakupan urusan dan nama instansi menghilang di "alihkan ke SP4N"](https://app.clickup.com/t/9003239225/CES-31403)

## Changes
[fix(diverted to span) : issue field coverage of affairs,opd name & other information not show on page detail](https://github.com/jabardigitalservice/super-app-cms/commit/cc260587f4af81d8b7506a45000cfd37d054f987)

## Evidence
title: fix issue field coverage of affairs,opd name & other information not show on page detail diverted to span
project: Sapawarga
participants: @marsellavaleria19 @DzikriAzzakah @agunghide @faisal-t @rayfajars @yoslie @ekadhirapratama 
screenshot: https://s.digitalservice.id/AGSAJJ
