### PR TITLE
feat(non goverment authority instruction) : add tab instruction on page list

### DIFF
--- a/components/Aduan/DaftarIKP/index.vue
+++ b/components/Aduan/DaftarIKP/index.vue
@@ -275,7 +275,9 @@ export default {
               ? ikpStatus.followup.icon
               : this.ikpStatus[item.id].icon,
           name:
-            this.ikpTypePage === ikpType.instruksiNonPemprov.props &&
+            (this.ikpTypePage === ikpType.instruksiNonPemprov.props ||
+              this.ikpTypePage ===
+                ikpType.instruksiKewenanganNonPemprov.props) &&
             item.id === 'coordinated'
               ? 'Sudah Dikoordinasikan'
               : ikpStatus[item.id].name,
@@ -427,7 +429,8 @@ export default {
     getStatusText(status) {
       switch (status) {
         case ikpStatus.coordinated.id:
-          return this.ikpTypePage === ikpType.instruksiNonPemprov.props
+          return this.ikpTypePage === ikpType.instruksiNonPemprov.props ||
+            this.ikpTypePage === ikpType.instruksiKewenanganNonPemprov.props
             ? 'Sudah Dikoordinasikan'
             : ikpStatus.coordinated.name
         case ikpStatus.followup.id:

--- a/components/Base/TabListString/index.vue
+++ b/components/Base/TabListString/index.vue
@@ -1,6 +1,10 @@
 <template>
-  <div class="w-full bg-green-600 h-fit flex items-center">
-    <div v-for="(tab,index) in listTab" :key="index" @click="setSelectedTab(tab)">
+  <div class="flex h-fit w-full items-center bg-green-600">
+    <div
+      v-for="(tab, index) in listTab"
+      :key="index"
+      @click="setSelectedTab(tab)"
+    >
       <slot :data-tab="tab" :index-tab="index" />
     </div>
   </div>
@@ -11,20 +15,20 @@ export default {
   name: 'BaseTabList',
   props: {
     listTab: {
-      type: Object,
+      type: Array,
       required: true,
-      default: () => ({})
-    }
+      default: () => [],
+    },
   },
-  data () {
+  data() {
     return {
-      dataTab: {}
+      dataTab: {},
     }
   },
   methods: {
-    setSelectedTab (data) {
+    setSelectedTab(data) {
       this.$emit('selected', data)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/components/TabBar/Menu/index.vue
+++ b/components/TabBar/Menu/index.vue
@@ -36,23 +36,23 @@ export default {
   name: 'TabBarMenu',
   props: {
     listTab: {
-      type: Object,
-      default: () => ({})
+      type: Array,
+      default: () => [],
     },
     idTab: {
       type: String,
-      default: ''
-    }
+      default: '',
+    },
   },
-  data () {
+  data() {
     return {
-      selectedTabId: this.idTab
+      selectedTabId: this.idTab,
     }
   },
   methods: {
-    selectedTabHandle (dataTab) {
+    selectedTabHandle(dataTab) {
       this.selectedTabId = dataTab.id
-    }
-  }
+    },
+  },
 }
 </script>

--- a/pages/aduan/instruksi-kewenangan-non-pemprov/index.vue
+++ b/pages/aduan/instruksi-kewenangan-non-pemprov/index.vue
@@ -1,17 +1,30 @@
 <template>
   <div>
+    <TabBarMenu
+      :list-tab="listTab"
+      class="mb-[18px]"
+      :id-tab="idTab"
+      @button-tab="clickTab"
+    />
     <Aduan
+      v-if="idTab === listTab[0].id"
       :type-aduan-page="typeAduan.instruksiKewenanganNonPemprov"
-      link-page-detail="/aduan/instruksi-kewenangan-non-pemprov/detail"
+      link-page-detail="/aduan/instruksi-kewenangan-pemprov/detail"
+    />
+    <AduanDaftarIKP
+      v-if="idTab === listTab[1].id"
+      :ikp-type-page="ikpType.instruksiKewenanganNonPemprov.props"
+      detail-page="/aduan/instruksi-kewenangan-non-pemprov/detail-ikp"
     />
   </div>
 </template>
 
 <script>
-import { typeAduan } from '~/constant/aduan-masuk.js'
+import { typeAduan } from '~/constant/aduan-masuk'
+import { ikpType } from '~/constant/daftar-ikp'
 
 export default {
-  name: 'PageInstruksiKewenanganPemprov',
+  name: 'PageInstruksiKewenanganNonPemprov',
   layout: 'Dashboard',
   data() {
     return {
@@ -24,14 +37,44 @@ export default {
       descriptionPage:
         'Berisi semua daftar aduan dari masyarakat Jabar yang perlu untuk dikoordinasikan.',
       typeAduan,
+      ikpType,
     }
   },
+  computed: {
+    listTab() {
+      return this.$store.state.listTab
+    },
+    idTab() {
+      return this.$store.state.idTab
+    },
+  },
+  watch: {
+    '$route.query': {
+      deep: true,
+      immediate: true,
+      handler(newQuery) {
+        if (Object.keys(newQuery).length > 0) {
+          this.$store.commit('setIdTab', null)
+          const { idTab } = newQuery
+          this.$tore.commit('setIdTab', idTab)
+        }
+      },
+    },
+  },
+  created() {
+    this.$store.commit('setIdTab', this.listTab[0].id)
+  },
   mounted() {
-    this.$store.commit('setActivePage', 'Instruksi Kewenangan Non-Pemprov')
+    this.$store.commit('setActivePage', 'Instruksi Kewenangan Non Pemprov')
     this.$store.commit('setHeader', {
       navigations: this.navigations,
       descriptionPage: this.descriptionPage,
     })
+  },
+  methods: {
+    clickTab(idTab) {
+      this.$store.dispatch('clickTab', idTab)
+    },
   },
 }
 </script>

--- a/pages/aduan/instruksi-kewenangan-non-pemprov/index.vue
+++ b/pages/aduan/instruksi-kewenangan-non-pemprov/index.vue
@@ -54,7 +54,6 @@ export default {
       immediate: true,
       handler(newQuery) {
         if (Object.keys(newQuery).length > 0) {
-          this.$store.commit('setIdTab', null)
           const { idTab } = newQuery
           this.$tore.commit('setIdTab', idTab)
         }

--- a/pages/aduan/instruksi-kewenangan-non-pemprov/index.vue
+++ b/pages/aduan/instruksi-kewenangan-non-pemprov/index.vue
@@ -55,7 +55,7 @@ export default {
       handler(newQuery) {
         if (Object.keys(newQuery).length > 0) {
           const { idTab } = newQuery
-          this.$tore.commit('setIdTab', idTab)
+          this.$store.commit('setIdTab', idTab)
         }
       },
     },

--- a/store/index.js
+++ b/store/index.js
@@ -7,6 +7,12 @@ export const state = () => ({
   dataImage: {},
   responseFile: {},
   backPage: false, // for control old query on page list
+  listTab: [
+    { id: 'complaint', name: 'Semua Aduan' },
+    { id: 'ikp', name: 'Daftar Instruksi Khusus Pimpinan' },
+  ],
+  tabSelect: '',
+  idTab: '',
 })
 
 export const actions = {
@@ -22,6 +28,9 @@ export const actions = {
       descriptionPage: dataHeader.descriptionPage,
     })
     commit('setActivePage', dataHeader.label)
+  },
+  clickTab({ state, commit }, idTab) {
+    commit('setIdTab', idTab)
   },
 }
 
@@ -42,5 +51,8 @@ export const mutations = {
   },
   setBackPage(state, backPage) {
     state.backPage = backPage
+  },
+  setIdTab(state, idTab) {
+    state.idTab = idTab
   },
 }


### PR DESCRIPTION
## Related
[Tambah Tab Instruksi Khusus Pimpinan di menu Instruksi Kewenangan Non-Pemprov](https://app.clickup.com/t/9003239225/CES-31714)

## Changes
[feat(non goverment authority instruction) : add tab instruction on page list](https://github.com/jabardigitalservice/super-app-cms/commit/b5e9718ed81f4788e980d0d83dcb5863e58b800f)

## Preview
<img width="2880" height="1563" alt="image" src="https://github.com/user-attachments/assets/992d7e69-e8a1-42c7-ac1c-680c834a959e" />


## Evidence

title: feat add tab instruction on page list feature non government authority instruction
project: Sapawarga
participants: @marsellavaleria19 @ekadhirapratama @sheilaazhara 
screenshot: https://s.digitalservice.id/E2QjaF
